### PR TITLE
binding: leverage the `GraphicsMagick-config` program during build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,11 +3,25 @@
     {
       'target_name': 'GraphicsMagick',
       'sources': [ 'GraphicsMagick.cc' ],
-      'library_dirs': [
-        '/usr/local/lib',
-        '/opt/local/lib',
+      'libraries': [
+        '<!@(GraphicsMagick-config --libs)'
       ],
-      'libraries': [ '-lGraphicsMagick' ],
+      'conditions': [
+        ['OS=="mac"', {
+          # cflags on OS X are stupid and have to be defined like this
+          'xcode_settings': {
+            'OTHER_CFLAGS': [
+              '<!@(GraphicsMagick-config --cflags)',
+              '<!@(GraphicsMagick-config --cppflags)'
+            ]
+          }
+        }, {
+          'cflags': [
+            '<!@(GraphicsMagick-config --cflags)',
+            '<!@(GraphicsMagick-config --cppflags)'
+          ],
+        }]
+      ]
     }
   ]
 }


### PR DESCRIPTION
Makes build work as expected on OS X.
