### PR TITLE
Fix dimensions for REQ_RECT_ARG.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphicsmagick2",
   "description": "Bindings to the graphicsmagick library",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "MIT",
   "author": "Izaak Schroeder",
   "contributors": [

--- a/src/GraphicsMagick.cc
+++ b/src/GraphicsMagick.cc
@@ -37,7 +37,7 @@
     static_cast<unsigned long>(width),                                  \
     static_cast<unsigned long>(height),                                 \
     static_cast<long>(x),                                               \
-    static_cast<long>(x),                                               \
+    static_cast<long>(y),                                               \
   };
 
 #define REQ_DOUBLE_ARG(I, VAR)                                          \


### PR DESCRIPTION
It seems that the x param was used in place of the Y param, making the offsets a bit funky.  This fixes it.